### PR TITLE
refactor: Simplify devShell names in Nix flake and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,28 +167,63 @@ nix build .#web-p2p-tunnel
 # The binary will be available in ./result/bin/web-p2p-tunnel
 ```
 
-### Development Shell
+### Development Shells
 
-The flake provides a development shell with Go and Node.js available:
+The flake provides development shells with necessary tools pre-configured.
+
+**Default Development Shell**
+
+This shell is for general development, including working on the Go parts of the project and running the test server.
 
 ```sh
-nix develop
+nix develop .
+# or simply:
+# nix develop
 ```
 
-Inside the shell:
+Inside the default shell:
 - The `web-p2p-tunnel` executable (built from the local source) is in your `PATH`.
-- The Go toolchain is available for building the Go programs.
-- Node.js and npm are available for working on the web interface in the `web` directory.
+- The Go toolchain is available for building the Go programs (`cmd/web-p2p-tunnel`, `cmd/signaling-server`).
+- Node.js and npm are also available in this shell for any general tasks.
+- This shell is best for working on the Go components or running the `web-p2p-tunnel` CLI.
+- For web UI development, use the `web` shell described below (`nix develop .#web`).
+- For running the test server, use the `test` shell described below (`nix develop .#test`).
+
+**Web Development Shell (`web`)**
+
+This shell is specifically for working on the web interface (`web` directory).
+
+```sh
+nix develop .#web
+```
+
+Inside the web development shell:
+- Node.js and npm are available.
+- Instructions:
   ```sh
-  cd web
+  # If not already there:
+  # cd web
   npm install
   npm run build
+  # or for development with auto-rebuild:
+  # npm run build-watch
   ```
 
-  The shell also provides Node.js for the `test-server`. To run the test server (which defaults to `http://localhost:8080`):
+**Test Server Shell (`test`)**
+
+This shell is for running the Node.js test server (`test-server` directory).
+
+```sh
+nix develop .#test
+```
+
+Inside the test server shell:
+- Node.js and npm are available.
+- Instructions:
   ```sh
-  cd test-server
+  # If not already there:
+  # cd test-server
   npm install
   npm start
   ```
-  You can then use `web-p2p-tunnel -tunnel-target-url http://localhost:8080` to tunnel to it.
+  The server will typically run on `http://localhost:8080`.

--- a/flake.nix
+++ b/flake.nix
@@ -87,20 +87,49 @@
           shellHook = ''
             echo "### web-p2p-tunnel Development Shell ###"
             echo "The 'web-p2p-tunnel' executable (built from local sources) is in your PATH."
-            echo "The Go toolchain and Node.js are also available."
+            echo "The Go toolchain and Node.js are also available for general tasks."
             echo ""
+            echo "This default shell is primarily for Go development and running the main CLI."
+            echo "For web UI development, use: nix develop .#web"
+            echo "For running the test server, use: nix develop .#test"
+            echo ""
+            echo "To run the main tunnel CLI (after building, or if using the pre-built one):"
+            echo "  web-p2p-tunnel -tunnel-target-url <your-local-server-url>"
+          '';
+        };
+
+        devShells.web = pkgs.mkShell {
+          name = "web-p2p-tunnel-web-dev-shell";
+          buildInputs = [
+            pkgs.nodejs         # For running npm commands in the 'web' directory
+          ];
+          shellHook = ''
+            echo "### web-p2p-tunnel Web Development Shell (nix develop .#web) ###"
+            echo "Node.js and npm are available."
             echo "To work on the web interface:"
-            echo "  cd web"
-            echo "  npm install"
-            echo "  npm run build (or npm run build-watch)"
+            echo "  1. If you haven't already, navigate to the 'web' directory: cd web"
+            echo "  2. Install dependencies: npm install"
+            echo "  3. Build the project: npm run build"
+            echo "  4. For development with auto-rebuild: npm run build-watch"
             echo ""
+            echo "The web assets will be built in the 'web/dist' directory."
+          '';
+        };
+
+        devShells.test = pkgs.mkShell {
+          name = "web-p2p-tunnel-test-server-dev-shell";
+          buildInputs = [
+            pkgs.nodejs         # For running npm commands in the 'test-server' directory
+          ];
+          shellHook = ''
+            echo "### web-p2p-tunnel Test Server Shell (nix develop .#test) ###"
+            echo "Node.js and npm are available."
             echo "To run the test server (listens on http://localhost:8080 by default):"
-            echo "  cd test-server"
-            echo "  npm install"
-            echo "  npm start"
+            echo "  1. If you haven't already, navigate to the 'test-server' directory: cd test-server"
+            echo "  2. Install dependencies: npm install"
+            echo "  3. Start the server: npm start"
             echo ""
-            echo "You can then tunnel to it using:"
-            echo "  web-p2p-tunnel -tunnel-target-url http://localhost:8080"
+            echo "You can then tunnel to it using the main 'web-p2p-tunnel' CLI from another terminal."
           '';
         };
 


### PR DESCRIPTION
- Renamed `webDevShell` to `web` and `testServerDevShell` to `test` in `flake.nix`.
- Updated `shellHook` messages in `flake.nix` to reflect the new names.
- Updated `README.md` to use the new simplified devShell names (`.#web`, `.#test`) and adjusted section titles/descriptions accordingly.