### PR TITLE
feat: Add runnable apps for web and test dev environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,33 @@ Ensure you have Nix installed with flakes enabled. See the [Nix documentation](h
 
 ### Usage
 
-To run the `web-p2p-tunnel` CLI directly using Nix:
+**Running the Tunnel CLI (Default App)**
+
+To run the `web-p2p-tunnel` CLI directly using Nix (this is the default behavior of `nix run`):
 
 ```sh
 nix run . -- -tunnel-target-url http://localhost:8080
 ```
 
 This will build and run the CLI, forwarding to your local server. The public signaling server `https://signal.andrewt.io` is automatically used.
+
+**Starting Web Development Watch Mode**
+
+To start the web development server (usually `npm run build-watch` in the `web` directory):
+```sh
+nix run .#web
+```
+This will change to the `web` directory, run `npm install`, and then `npm run build-watch`.
+
+**Starting the Test Server**
+
+To start the test server (usually `npm start` in the `test-server` directory):
+```sh
+nix run .#test
+```
+This will change to the `test-server` directory, run `npm install`, and then `npm start`. The test server typically runs on `http://localhost:8080`.
+
+**Building Binaries**
 
 To build the `web-p2p-tunnel` binary:
 

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,30 @@
         # The defaultApp is what runs when you execute 'nix run' without specifying an app.
         defaultApp = self.apps.${system}.default;
 
+        apps.web = {
+          type = "app";
+          program = pkgs.writeShellScriptBin "run-web-dev" ''
+            #!${pkgs.stdenv.shell}
+            echo "### Starting Web Development Environment (from 'web' directory) ###"
+            echo "Running: npm install && npm run build-watch"
+            cd web
+            ${pkgs.nodejs}/bin/npm install
+            ${pkgs.nodejs}/bin/npm run build-watch
+          '';
+        };
+
+        apps.test = {
+          type = "app";
+          program = pkgs.writeShellScriptBin "run-test-server" ''
+            #!${pkgs.stdenv.shell}
+            echo "### Starting Test Server (from 'test-server' directory) ###"
+            echo "Running: npm install && npm start"
+            cd test-server
+            ${pkgs.nodejs}/bin/npm install
+            ${pkgs.nodejs}/bin/npm start
+          '';
+        };
+
         # 'devShells' define development environments.
         devShells.default = pkgs.mkShell {
           name = "web-p2p-tunnel-dev-shell";


### PR DESCRIPTION
- Added new `apps` named `web` and `test` to `flake.nix`.
  - `nix run .#web` now executes 'cd web && npm install && npm run build-watch'.
  - `nix run .#test` now executes 'cd test-server && npm install && npm start'.
- Updated README.md to document these new convenient `nix run` commands.