### PR TITLE
fix: Update WebRTC ICE server configuration

### DIFF
--- a/cmd/web-p2p-tunnel/main.go
+++ b/cmd/web-p2p-tunnel/main.go
@@ -30,7 +30,31 @@ var (
 	)
 
 	defaultWebrtcConfig = webrtc.Configuration{
-		ICEServers: []webrtc.ICEServer{{URLs: []string{"stun:stun.l.google.com:19302"}}},
+		ICEServers: []webrtc.ICEServer{
+			{
+				URLs: []string{"stun:stun.relay.metered.ca:80"},
+			},
+			{
+				URLs:       []string{"turn:global.relay.metered.ca:80"},
+				Username:   "0ef6af9aa09b1635b8ab1a58",
+				Credential: "uBnm6E/lVSPispsL",
+			},
+			{
+				URLs:       []string{"turn:global.relay.metered.ca:80?transport=tcp"},
+				Username:   "0ef6af9aa09b1635b8ab1a58",
+				Credential: "uBnm6E/lVSPispsL",
+			},
+			{
+				URLs:       []string{"turn:global.relay.metered.ca:443"},
+				Username:   "0ef6af9aa09b1635b8ab1a58",
+				Credential: "uBnm6E/lVSPispsL",
+			},
+			{
+				URLs:       []string{"turns:global.relay.metered.ca:443?transport=tcp"},
+				Username:   "0ef6af9aa09b1635b8ab1a58",
+				Credential: "uBnm6E/lVSPispsL",
+			},
+		},
 	}
 )
 

--- a/web/src/webrtc.ts
+++ b/web/src/webrtc.ts
@@ -1,6 +1,30 @@
 export async function connectWebRTC(sc: WebSocket, statusEl: HTMLElement) {
   const pc = new RTCPeerConnection({
-    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+    iceServers: [
+      {
+        urls: "stun:stun.relay.metered.ca:80",
+      },
+      {
+        urls: "turn:global.relay.metered.ca:80",
+        username: "0ef6af9aa09b1635b8ab1a58",
+        credential: "uBnm6E/lVSPispsL",
+      },
+      {
+        urls: "turn:global.relay.metered.ca:80?transport=tcp",
+        username: "0ef6af9aa09b1635b8ab1a58",
+        credential: "uBnm6E/lVSPispsL",
+      },
+      {
+        urls: "turn:global.relay.metered.ca:443",
+        username: "0ef6af9aa09b1635b8ab1a58",
+        credential: "uBnm6E/lVSPispsL",
+      },
+      {
+        urls: "turns:global.relay.metered.ca:443?transport=tcp",
+        username: "0ef6af9aa09b1635b8ab1a58",
+        credential: "uBnm6E/lVSPispsL",
+      },
+    ],
   });
 
   statusEl.innerText = pc.connectionState;


### PR DESCRIPTION
- Updated the default ICE server list in `cmd/web-p2p-tunnel/main.go` for the Go WebRTC client.
- Updated the ICE server list in `web/src/webrtc.ts` for the TypeScript WebRTC client.

Both now use the new set of STUN/TURN servers provided by Metered.