### PR TITLE
fix: Correct program path for web and test apps in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,26 +75,26 @@
 
         apps.web = {
           type = "app";
-          program = pkgs.writeShellScriptBin "run-web-dev" ''
+          program = "${pkgs.writeShellScriptBin "run-web-dev" ''
             #!${pkgs.stdenv.shell}
             echo "### Starting Web Development Environment (from 'web' directory) ###"
             echo "Running: npm install && npm run build-watch"
             cd web
             ${pkgs.nodejs}/bin/npm install
             ${pkgs.nodejs}/bin/npm run build-watch
-          '';
+          ''}/bin/run-web-dev";
         };
 
         apps.test = {
           type = "app";
-          program = pkgs.writeShellScriptBin "run-test-server" ''
+          program = "${pkgs.writeShellScriptBin "run-test-server" ''
             #!${pkgs.stdenv.shell}
             echo "### Starting Test Server (from 'test-server' directory) ###"
             echo "Running: npm install && npm start"
             cd test-server
             ${pkgs.nodejs}/bin/npm install
             ${pkgs.nodejs}/bin/npm start
-          '';
+          ''}/bin/run-test-server";
         };
 
         # 'devShells' define development environments.


### PR DESCRIPTION
Ensures that `apps.web.program` and `apps.test.program` correctly reference the executable scripts generated by `pkgs.writeShellScriptBin` by using the `${...}/bin/script-name` syntax.

This allows `nix run .#web` and `nix run .#test` to function as intended.